### PR TITLE
fix: don't let ProgressPrinter block the main flow

### DIFF
--- a/zk/utils.go
+++ b/zk/utils.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ledgerwatch/log/v3"
 	"sync"
+
+	"github.com/ledgerwatch/log/v3"
 )
 
 var ErrLimboState = errors.New("Calculating limbo state")
@@ -14,7 +15,7 @@ var ErrLimboState = errors.New("Calculating limbo state")
 // prints progress every 10 seconds
 // returns a channel to send progress to, and a function to stop the printer routine
 func ProgressPrinter(message string, total uint64, quiet bool) (chan uint64, func()) {
-	progress := make(chan uint64)
+	progress := make(chan uint64, total)
 	ctDone := make(chan bool)
 	var once sync.Once
 


### PR DESCRIPTION
- fix: make the ProgressPrinter's channel buffered

Currently, the sending side must wait for the ProcessPrinter to process the
channel message before continuing. This makes the main flow slow. This commit
make the channel buffered with the capacity equal to total expected number of
messages.

- fix: make ProgressPrinter's channel send non-blocking

The ProgressPrinter is for logging only so make the channel send non-blocking to
prevent it from blocking the main flow. In case we don't want to print progress,
don't create or send to the channel.